### PR TITLE
Fix endpoints paths to be as required

### DIFF
--- a/src/monument/router/monumentsRouter.ts
+++ b/src/monument/router/monumentsRouter.ts
@@ -8,11 +8,8 @@ const monumentController = new MonumentController(monuments);
 
 monumentsRouter.get("/", monumentController.getMonuments);
 
-monumentsRouter.post("/add-monument", monumentController.addMonuments);
+monumentsRouter.post("/", monumentController.addMonuments);
 
-monumentsRouter.delete(
-  "/delete/:monumentId",
-  monumentController.deleteMonument,
-);
+monumentsRouter.delete("/:monumentId", monumentController.deleteMonument);
 
 export default monumentsRouter;


### PR DESCRIPTION
Fix endpoints paths to be as required:
- GET /monuments
- POST /monuments
- DELETE /monuments/:monumentId